### PR TITLE
Fix initiation order

### DIFF
--- a/CSV_Parser.cpp
+++ b/CSV_Parser.cpp
@@ -64,17 +64,17 @@ void CSV_Parser::AssignIsFmtUnsignedArray(const char * fmt_) {
 }
 
 CSV_Parser::CSV_Parser(const char * s, const char * fmt_, bool has_header_, char delimiter_, char quote_char_) :
+  fmt( strdup_ignoring_u(fmt_) ),
   rows_count(NULL), 
   cols_count( strlen_ignoring_u(fmt_) ),
-  fmt( strdup_ignoring_u(fmt_) ),
   has_header(has_header_),
   delimiter(delimiter_),
   quote_char(quote_char_),
   delim_chars({'\r', '\n', delimiter_, 0}),
-  leftover(NULL),
-  current_col(NULL),
   whole_csv_supplied(false),
   //whole_csv_supplied((bool)s ? true : false), // in constructor where whole csv is not supplied at once it should be set to false
+  leftover(NULL),
+  current_col(NULL),
   header_parsed(!has_header_)
 {  
   AssignIsFmtUnsignedArray(fmt_);
@@ -441,3 +441,4 @@ void CSV_Parser::parseLeftover() {
     leftover = 0;
   }
 }
+

--- a/CSV_Parser.cpp
+++ b/CSV_Parser.cpp
@@ -441,4 +441,3 @@ void CSV_Parser::parseLeftover() {
     leftover = 0;
   }
 }
-


### PR DESCRIPTION
Hi,
I try to use CSV-Parser on [m5stack-fire](https://m5stack.com/products/fire-iot-development-kit) through [platform.io library](https://platformio.org/lib/show/7467/CSV%20Parser).
But compile failed, because initiation order mismatched on constructor.
So, I fixed it.