### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ char    *chars =             (char*)cp["my_chars"];
 float   *floats =           (float*)cp["my_floats"];
 int32_t *longs_from_hex = (int32_t*)cp["my_hex"];    // CSV_Parser stores hex as longs (casting to int* would point to wrong address when ints[ind] is used)
 
-for (int i = 0; i < cp.GetRowsCount(); i++) {
+for (int i = 0; i < cp.getRowsCount(); i++) {
     Serial.print(strings[i]);             Serial.print(" - ");
     Serial.print(longs[i], DEC);          Serial.print(" - ");
     Serial.print(ints[i], DEC);           Serial.print(" - ");


### PR DESCRIPTION
There was a bug where the call to `cp.GetRowsCount()` was incorrectly using an uppercase `G` rather than a lowercase `g`.  This causes the error below.  I fixed this to be `cp.getRowsCount()`.

```
C:\Users\zam26\Documents\Code\Arduino\Projects\SunriseSunset\SunriseSunset.ino: In function 'void setup()':
SunriseSunset:47:26: error: 'class CSV_Parser' has no member named 'GetRowsCount'; did you mean 'getRowsCount'?
   for (int i = 0; i < cp.GetRowsCount(); i++) {
                          ^~~~~~~~~~~~
                          getRowsCount
exit status 1
'class CSV_Parser' has no member named 'GetRowsCount'; did you mean 'getRowsCount'?
```